### PR TITLE
`Storage.remove(key)` method for removal of a key-value pair based on `key`

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -12,9 +12,12 @@ class Storage:
         else:
             return None
 
-    def remove(self):
-        pass
-
+    def remove(self, key):
+        from collections import Hashable
+        if not isinstance(key, Hashable):
+            return None # given key is a mutable object (thus cannot be a dict's key by Python rules)
+        return self.data.pop(key, None) # if key isn't found, returns default=None
+        
     def set(self):
         pass
     

--- a/tests.py
+++ b/tests.py
@@ -4,7 +4,46 @@ def test_add():
     pass
 
 def test_remove():
-    pass
+    st = Storage({
+        'a': 1, 
+        'b': 2, 
+        9999: 3.0, 
+        42.42: 4,
+    })
+    # test removing of existent keys
+    def test_existent_key(key, expected_val):
+        assert st.get(key) is not None, f"!! Test is misconfigured: key={key} doesn't exist, but was expected to exist"
+        previous_len = len(st.data)
+        removed_val = st.remove(key)
+        assert removed_val == expected_val, f"Returned value of removed key={key} is={removed_val}, but was expected to be={expected_val}" 
+        assert st.get(key) is None, f"Removed key={key} is still present, but was expected otherwise"
+        # FIXME(alexey larionov) this test should also check that other key-value pairs are not 
+        # changed, but comparison of lengths is just easier, yet not totally reliable
+        removed_pairs = previous_len - len(st.data)
+        assert removed_pairs == 1, f"After removing one of the keys, {removed_pairs} key-value pairs were removed, but only 1 was expected"
+    test_existent_key('b', 2)
+    test_existent_key(9999, 3.0)
+    test_existent_key(42.42, 4)
+    
+    # test removing of non-existent keys
+    def test_non_existent_key(key):
+        assert st.get(key) is None, f"!! Test is misconfigured: key={key} already exists, but should've not"
+        removed_val = st.remove(key)
+        assert removed_val is None, f"Removing of non-existent key={key} returned={removed_val}, but was expected to return None"
+        assert st.get(key) is None, f"Removing of non-existent key={key} created this key, but should've not"
+        
+    test_non_existent_key('c')
+    test_non_existent_key(5)
+    test_non_existent_key(11.11)
+
+    # test removing of values that cannot be keys (mutable objects)
+    def test_invalid_key(key):
+        assert st.remove(key) is None, f"Removing of a mutable object key={key} was expected to return None"
+        # FIXME(alexey larionov): this test should assert that st.get(key) with an 
+        # invalid (mutable) key returns None before and after removal,
+        # but it can't be done because st.get(key) throws an expection in such case
+    test_invalid_key([1, 2, 3])
+    test_invalid_key({ 'z': st })
 
 def test_set():
     pass


### PR DESCRIPTION
The `Storage.remove(key)` is expected to be exception-free. 

- If the `key` is not present, it returns `None`
- If the `key` is present, it removes the key-value pair and returns the `value` that was removed
- If the `key` is an invalid key (i.e. it's a mutable object that by Python rules is not hashable and thus cannot be a `dict`'s key) then it returns None

The tests assert these three cases with different input, they also do a few sanity checks that removal doesn't leave the key untouched, or that it removes more than one key. It has to be noted that tests don't completely check that the storage preserves its invariant